### PR TITLE
Bunch of changes to ensure attack/fade stay within proper limits.

### DIFF
--- a/ForceEffects/ForceEffect.cpp
+++ b/ForceEffects/ForceEffect.cpp
@@ -380,10 +380,10 @@ void ForceEffect::setDelay(double newDelay)
 
 void ForceEffect::setDuration(double newDuration, bool setInfinite /* = false */)
 {
-    newDuration = qMax(0.0, qMin(32.767, newDuration));
+    newDuration = qMax(0.1, qMin(32.767, newDuration));
     int duration = qRound(newDuration * 1000);
 
-    if (setInfinite || (0 == duration))
+    if (setInfinite)
     {
         if (!isInfiniteDuration())
         {
@@ -407,8 +407,8 @@ void ForceEffect::setDuration(double newDuration, bool setInfinite /* = false */
                 emit durationIsInfiniteChanged(false);
                 emit valuesChanged();
             }
-            setAttackLength(qMin(attackLength(), newDuration - fadeLength()));
-            setFadeLength(qMin(fadeLength(), newDuration - attackLength()));
+            setAttackLength(qMin(attackLength(), qMax(0.0, newDuration - fadeLength())));
+            setFadeLength(qMin(fadeLength(), qMax(0.0, newDuration - attackLength())));
             update();
         }
     }
@@ -460,6 +460,10 @@ void ForceEffect::setAttackLevel(double newLevel)
 void ForceEffect::setAttackLength(double newLength)
 {
     Q_ASSERT(m_envelope);
+    if (!isInfiniteDuration())
+    {
+        newLength = qMin(duration(), newLength);
+    }
     m_envelope->setAttackLength(newLength);
     if (!isInfiniteDuration() && ((duration() - fadeLength()) < attackLength()))
     {
@@ -478,6 +482,10 @@ void ForceEffect::setFadeLevel(double newLevel)
 void ForceEffect::setFadeLength(double newLength)
 {
     Q_ASSERT(m_envelope);
+    if (!isInfiniteDuration())
+    {
+        newLength = qMin(duration(), newLength);
+    }
     m_envelope->setFadeLength(newLength);
     if (!isInfiniteDuration() && ((duration() - fadeLength()) < attackLength()))
     {

--- a/ForceEffects/ForceEnvelope.cpp
+++ b/ForceEffects/ForceEnvelope.cpp
@@ -118,7 +118,7 @@ void ForceEnvelope::setAttackLength(double newLength)
 {
     if (exists())
     {
-        int length = qRound(newLength * 1000.0);
+        int length = qMax(0, qRound(newLength * 1000.0));
         if (length != m_envelope->attack_length)
         {
             m_envelope->attack_length = length;
@@ -144,7 +144,7 @@ void ForceEnvelope::setFadeLength(double newLength)
 {
     if (exists())
     {
-        int length = qRound(newLength * 1000.0);
+        int length = qMax(0, qRound(newLength * 1000.0));
         if (length != m_envelope->fade_length)
         {
             m_envelope->fade_length = length;

--- a/Widgets/DurationWidget.cpp
+++ b/Widgets/DurationWidget.cpp
@@ -42,7 +42,7 @@ DurationWidget::DurationWidget(QWidget *parent) :
     connect(ui->durationSpinBox, SIGNAL(valueChanged(double)), this, SLOT(onDurationChanged(double)));
     connect(ui->infiniteCheckBox, SIGNAL(clicked(bool)), this, SLOT(onDurationIsInfiniteChanged(bool)));
 
-    ui->durationSpinBox->setRange(0.0, 32.767);
+    ui->durationSpinBox->setRange(0.1, 32.767);
     ui->durationSpinBox->setSingleStep(0.1);
 }
 

--- a/Widgets/EnvelopeWidget.cpp
+++ b/Widgets/EnvelopeWidget.cpp
@@ -138,5 +138,8 @@ void EnvelopeWidget::updateUserInterface(void)
         bool isInfinite = m_force->isInfiniteDuration();
         ui->fadeLevelSpinBox->setEnabled(!isInfinite);
         ui->fadeLengthSpingBox->setEnabled(!isInfinite);
+
+        ui->attackLengthSpinBox->setRange(0.0, m_force->duration());
+        ui->fadeLengthSpingBox->setRange(0.0, m_force->duration());
     }
 }


### PR DESCRIPTION
Also circumventing the zero-duration bug by not allowing effects
shorter than 0.1 seconds.

Fixes special cases of #5
